### PR TITLE
Refactor/#42 - 교내공지 관련 기능 수정

### DIFF
--- a/app/src/main/java/com/example/gaechuck/api/ApiService.kt
+++ b/app/src/main/java/com/example/gaechuck/api/ApiService.kt
@@ -155,7 +155,7 @@ interface ApiService {
     @GET("/api/v1/notifications/allNotification")
     suspend fun getAllNoticeData(
         @Query("page") page: Int,
-        @Query("size") pageSize: Int,
+        @Query("size") size: Int,
         @Query("bbsId") bbsId: String? = null
     ): BaseResponse<List<GetAllNoticeDataResponse>>
 

--- a/app/src/main/java/com/example/gaechuck/data/model/NoticeUnivModel.kt
+++ b/app/src/main/java/com/example/gaechuck/data/model/NoticeUnivModel.kt
@@ -1,11 +1,13 @@
 package com.example.gaechuck.data.model
 
 data class NoticeUnivModel(
-    val id: Int,
+    val notiSeq: Int,
+    val notiNum: String,
     val title: String,
-    val body: String?,
-    val representationImages: String?,
-    val time: String?,
+    val regiDate: String,
+    val categoryName: String?,
     val departmentName: String?,
-    val bbsId: String?
+    val url: String,
+    val bbsId: String,
+    val dataId: String
 )

--- a/app/src/main/java/com/example/gaechuck/data/response/GetAllNoticeDataResponse.kt
+++ b/app/src/main/java/com/example/gaechuck/data/response/GetAllNoticeDataResponse.kt
@@ -1,11 +1,13 @@
 package com.example.gaechuck.data.response
 
 data class GetAllNoticeDataResponse(
-        val bbsId: String,
-        val id: Int,
+        val notiSeq: Int,
+        val notiNum: String,
         val title: String,
-        val body: String,
-        val representationImages: String,
-        val time: String,
-        val departmentName: String?
+        val regiDate: String,
+        val categoryName: String?,
+        val departmentName: String?,
+        val url: String,
+        val bbsId: String,
+        val dataId: String
 )

--- a/app/src/main/java/com/example/gaechuck/data/response/GetUnivNoticeDataResponse.kt
+++ b/app/src/main/java/com/example/gaechuck/data/response/GetUnivNoticeDataResponse.kt
@@ -1,9 +1,0 @@
-package com.example.gaechuck.data.response
-
-data class GetUnivNoticeDataResponse(
-        val body: String,
-        val id: Int,
-        val representationImages: String,
-        val time: String,
-        val title: String
-)

--- a/app/src/main/java/com/example/gaechuck/data/response/GetUnivNoticeDetailResponse.kt
+++ b/app/src/main/java/com/example/gaechuck/data/response/GetUnivNoticeDetailResponse.kt
@@ -1,8 +1,0 @@
-package com.example.gaechuck.data.response
-
-data class GetUnivNoticeDetailResponse(
-        val body: String,
-        val images: List<String>,
-        val time: String,
-        val title: String
-)

--- a/app/src/main/java/com/example/gaechuck/repository/NoticeUnivRepository.kt
+++ b/app/src/main/java/com/example/gaechuck/repository/NoticeUnivRepository.kt
@@ -9,19 +9,17 @@ class NoticeUnivRepository {
     private val apiService = ApiConnection.getRetrofitService
 
     // 교내 공지 리스트 가져오기
-    suspend fun getNoticeUnivList(page: Int, pageSize: Int, bbsId: String): List<NoticeUnivModel> {
+    suspend fun getNoticeUnivList(page: Int, bbsId: String): Pair<List<NoticeUnivModel>, Boolean> {
         return try {
 
             val requestBbsId = if (bbsId.isNullOrEmpty()) "2" else bbsId
+            val maxSize = 100
 
-            Log.d("API_REQUEST", "Fetching notices with page=$page, pageSize=$pageSize, bbsId=$requestBbsId")
-
-            val result = apiService.getAllNoticeData(page, pageSize, requestBbsId)
-
+            val result = apiService.getAllNoticeData(page, maxSize, requestBbsId)
             if (result.isSuccess && result.result != null) {
                 Log.d("API_SUCCESS", "Response: ${result.result}")
 
-                result.result.map {
+                val notices = result.result.map {
                     NoticeUnivModel(
                         id = it.id,
                         title = it.title,
@@ -32,6 +30,12 @@ class NoticeUnivRepository {
                         bbsId = it.bbsId
                     )
                 }
+
+                // 데이터 로그 출력
+                Log.d("API_SUCCESS", "Page: $page, Fetched: ${notices.size} items")
+
+                val hasMoreData = notices.isNotEmpty()
+                Pair(notices, hasMoreData)
 
             } else {
                 Log.e("API_ERROR", "Error Message: ${result.message}")

--- a/app/src/main/java/com/example/gaechuck/repository/NoticeUnivRepository.kt
+++ b/app/src/main/java/com/example/gaechuck/repository/NoticeUnivRepository.kt
@@ -22,13 +22,15 @@ class NoticeUnivRepository {
 
                 val notices = result.result.map {
                     NoticeUnivModel(
-                        id = it.id,
+                        notiSeq = it.notiSeq,
+                        notiNum = it.notiNum,
                         title = it.title,
-                        body = it.body,
-                        representationImages = it.representationImages,
-                        time = it.time,
+                        regiDate = it.regiDate,
+                        categoryName = it.categoryName,
                         departmentName = it.departmentName,
-                        bbsId = it.bbsId
+                        url = it.url,
+                        bbsId = it.bbsId,
+                        dataId = it.dataId
                     )
                 }
 
@@ -52,13 +54,15 @@ class NoticeUnivRepository {
 
     private fun GetAllNoticeDataResponse.toNoticeUnivModel(): NoticeUnivModel {
         return NoticeUnivModel(
-            id = this.id,
+            notiSeq = this.notiSeq,
+            notiNum = this.notiNum,
             title = this.title,
-            body = this.body,
-            representationImages = this.representationImages,
-            time = this.time,
+            regiDate = this.regiDate,
+            categoryName = this.categoryName,
             departmentName = this.departmentName,
-            bbsId = this.bbsId
+            url = this.url,
+            bbsId = this.bbsId,
+            dataId = this.dataId
         )
     }
 

--- a/app/src/main/java/com/example/gaechuck/repository/NoticeUnivRepository.kt
+++ b/app/src/main/java/com/example/gaechuck/repository/NoticeUnivRepository.kt
@@ -13,11 +13,12 @@ class NoticeUnivRepository {
         return try {
 
             val requestBbsId = if (bbsId.isNullOrEmpty()) "2" else bbsId
-            val maxSize = 100
+            val size = 1000
 
-            val result = apiService.getAllNoticeData(page, maxSize, requestBbsId)
+            Log.d("API_REQUEST", "🔹 Fetching notices → page=$page, size=$size, bbsId=$requestBbsId")
+
+            val result = apiService.getAllNoticeData(page, size, requestBbsId)
             if (result.isSuccess && result.result != null) {
-                Log.d("API_SUCCESS", "Response: ${result.result}")
 
                 val notices = result.result.map {
                     NoticeUnivModel(
@@ -31,8 +32,10 @@ class NoticeUnivRepository {
                     )
                 }
 
-                // 데이터 로그 출력
-                Log.d("API_SUCCESS", "Page: $page, Fetched: ${notices.size} items")
+                Log.d("API_SUCCESS", "Page: $page → Fetched: ${notices.size} items")
+
+                val totalDataCount = notices.size
+                Log.d("API_SUCCESS", "Total fetched so far: ${totalDataCount} items")
 
                 val hasMoreData = notices.isNotEmpty()
                 Pair(notices, hasMoreData)

--- a/app/src/main/java/com/example/gaechuck/repository/NoticeUnivRepository.kt
+++ b/app/src/main/java/com/example/gaechuck/repository/NoticeUnivRepository.kt
@@ -11,15 +11,16 @@ class NoticeUnivRepository {
     // 교내 공지 리스트 가져오기
     suspend fun getNoticeUnivList(page: Int, pageSize: Int, bbsId: String): List<NoticeUnivModel> {
         return try {
-            val requestBbsId = if (bbsId == "전체") null else bbsId
+
+            val requestBbsId = if (bbsId.isNullOrEmpty()) "2" else bbsId
 
             Log.d("API_REQUEST", "Fetching notices with page=$page, pageSize=$pageSize, bbsId=$requestBbsId")
 
             val result = apiService.getAllNoticeData(page, pageSize, requestBbsId)
+
             if (result.isSuccess && result.result != null) {
                 Log.d("API_SUCCESS", "Response: ${result.result}")
 
-                // ✅ map을 통해 List<NoticeUnivModel>로 변환
                 result.result.map {
                     NoticeUnivModel(
                         id = it.id,
@@ -27,8 +28,8 @@ class NoticeUnivRepository {
                         body = it.body,
                         representationImages = it.representationImages,
                         time = it.time,
-                        departmentName = it.departmentName, // ✅ departmentName 추가
-                        bbsId = it.bbsId                    // ✅ bbsId 추가
+                        departmentName = it.departmentName,
+                        bbsId = it.bbsId
                     )
                 }
 

--- a/app/src/main/java/com/example/gaechuck/ui/noticeuniv/NoticeUnivActivity.kt
+++ b/app/src/main/java/com/example/gaechuck/ui/noticeuniv/NoticeUnivActivity.kt
@@ -87,6 +87,7 @@ class NoticeUnivActivity : AppCompatActivity() {
                 val lastVisibleItem = layoutManager.findLastVisibleItemPosition()
 
                 if (!viewModel.isLoading && viewModel.hasMoreData && lastVisibleItem + 1 >= totalItemCount) {
+                    Log.d("SCROLL", "Loading more data... Current page: ${viewModel.currentPage}")
                     viewModel.loadMoreNotices(currentBbsId)
                 }
             }
@@ -128,8 +129,9 @@ class NoticeUnivActivity : AppCompatActivity() {
             textView.setOnClickListener {
                 selectTab(textView, underlines[index])
                 currentBbsId = textView.text.toString()
-                viewModel.hasMoreData = true
-                viewModel.currentPage = 0
+
+                val recyclerView = findViewById<RecyclerView>(R.id.noticeRecyclerView)
+                recyclerView.scrollToPosition(0)
                 viewModel.fetchNotices(0, currentBbsId)
             }
         }

--- a/app/src/main/java/com/example/gaechuck/ui/noticeuniv/NoticeUnivActivity.kt
+++ b/app/src/main/java/com/example/gaechuck/ui/noticeuniv/NoticeUnivActivity.kt
@@ -17,6 +17,7 @@ import com.example.gaechuck.repository.NoticeUnivRepository
 import com.example.gaechuck.ui.noticeuniv.adaptor.NoticeUnivAdapter
 import com.example.gaechuck.ui.noticeuniv.viewmodel.NoticeUnivViewModel
 import com.example.gaechuck.ui.noticeuniv.viewmodel.NoticeUnivViewModelFactory
+import okhttp3.internal.format
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
@@ -26,10 +27,7 @@ class NoticeUnivActivity : AppCompatActivity() {
     private lateinit var noticeUnivAdapter: NoticeUnivAdapter
     private lateinit var viewModel: NoticeUnivViewModel
     private lateinit var dateTextView: TextView
-    private var currentPage = 0
-    private val itemsPerPage = 10
     private var currentBbsId: String = "기관"
-    private var isLoading = false
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -54,10 +52,6 @@ class NoticeUnivActivity : AppCompatActivity() {
             startActivity(intent)
         }
 
-        val noticeDateTextView: TextView = findViewById(R.id.noticeDateTextView)
-        val currentDate = SimpleDateFormat("MM월 dd일", Locale.getDefault()).format(Date())
-        noticeDateTextView.text = currentDate
-
         initRecyclerView()
         observeViewModel()
 
@@ -66,7 +60,6 @@ class NoticeUnivActivity : AppCompatActivity() {
         viewModel.fetchNotices(0, currentBbsId)
 
         val tabAll = findViewById<TextView>(R.id.tabInstitution)
-//        val tabAllUnderline = findViewById<View>(R.id.tabAllUnderline)
         val tabAllUnderline = findViewById<View>(R.id.tabInstitutionUnderline)
         selectTab(tabAll, tabAllUnderline)
 
@@ -80,6 +73,8 @@ class NoticeUnivActivity : AppCompatActivity() {
         recyclerView.adapter = noticeUnivAdapter
         recyclerView.layoutManager = LinearLayoutManager(this)
 
+        val dateTextView = findViewById<TextView>(R.id.noticeDateTextView)
+
         recyclerView.addOnScrollListener(object : RecyclerView.OnScrollListener() {
             override fun onScrolled(recyclerView: RecyclerView, dx: Int, dy: Int) {
                 val layoutManager = recyclerView.layoutManager as LinearLayoutManager
@@ -87,9 +82,17 @@ class NoticeUnivActivity : AppCompatActivity() {
                 val lastVisibleItem = layoutManager.findLastVisibleItemPosition()
 
                 if (!viewModel.isLoading && viewModel.hasMoreData && lastVisibleItem + 1 >= totalItemCount) {
-                    Log.d("SCROLL", "Loading more data... Current page: ${viewModel.currentPage}")
                     viewModel.loadMoreNotices(currentBbsId)
                 }
+
+                val firstVisibleItemPosition = layoutManager.findFirstVisibleItemPosition()
+                if (firstVisibleItemPosition != RecyclerView.NO_POSITION) {
+                    val firstVisibleItem = noticeUnivAdapter.getItem(firstVisibleItemPosition)
+                    firstVisibleItem?.let {
+                        dateTextView.text = formatDate(it.regiDate)
+                    }
+                }
+
             }
         })
     }
@@ -161,5 +164,16 @@ class NoticeUnivActivity : AppCompatActivity() {
 
         allTabs.forEach { it.setTextColor(resources.getColor(R.color.tab_colors)) }
         selectedTab.setTextColor(resources.getColor(R.color.gnu_blue))
+    }
+
+    private fun formatDate(regiDate: String): String {
+        return try {
+            val inputFormat = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault())
+            val outputFormat = SimpleDateFormat("MM월 dd일", Locale.getDefault())
+            val date = inputFormat.parse(regiDate)
+            outputFormat.format(date!!)
+        } catch (e: Exception) {
+            "날짜 오류"
+        }
     }
 }

--- a/app/src/main/java/com/example/gaechuck/ui/noticeuniv/NoticeUnivActivity.kt
+++ b/app/src/main/java/com/example/gaechuck/ui/noticeuniv/NoticeUnivActivity.kt
@@ -4,7 +4,9 @@ import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
 import android.util.Log
+import android.view.KeyEvent
 import android.view.View
+import android.widget.EditText
 import android.widget.ImageView
 import android.widget.TextView
 import android.widget.Toast
@@ -22,6 +24,7 @@ import okhttp3.internal.format
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
+import java.util.Queue
 
 
 class NoticeUnivActivity : AppCompatActivity() {
@@ -55,6 +58,8 @@ class NoticeUnivActivity : AppCompatActivity() {
 
         initRecyclerView()
         observeViewModel()
+        initSearch()
+
 
         // 데이터 로드
         Log.d("Activity", "Fetching notices onCreate")
@@ -69,7 +74,7 @@ class NoticeUnivActivity : AppCompatActivity() {
 
     private fun initRecyclerView() {
         val recyclerView = findViewById<RecyclerView>(R.id.noticeRecyclerView)
-        recyclerView.setLayerType(View.LAYER_TYPE_SOFTWARE, null)
+        recyclerView.setLayerType(View.LAYER_TYPE_HARDWARE, null)
         noticeUnivAdapter = NoticeUnivAdapter(mutableListOf()) { url ->
             openUrl(url)
         }
@@ -136,9 +141,15 @@ class NoticeUnivActivity : AppCompatActivity() {
                 selectTab(textView, underlines[index])
                 currentBbsId = textView.text.toString()
 
+                val searchEditText = findViewById<EditText>(R.id.searchEditText)
+                searchEditText.text.clear()
+
+                noticeUnivAdapter.filter("")
+                viewModel.fetchNotices(0, currentBbsId)
+
+
                 val recyclerView = findViewById<RecyclerView>(R.id.noticeRecyclerView)
                 recyclerView.scrollToPosition(0)
-                viewModel.fetchNotices(0, currentBbsId)
             }
         }
     }
@@ -183,5 +194,51 @@ class NoticeUnivActivity : AppCompatActivity() {
     private fun openUrl(url: String) {
         val intent = Intent(Intent.ACTION_VIEW, Uri.parse(url))
         startActivity(intent)
+    }
+
+    private fun initSearch() {
+        val searchEditText = findViewById<EditText>(R.id.searchEditText)
+        val searchButton = findViewById<ImageView>(R.id.searchButton)
+
+        // 🔍 검색 버튼 클릭 시
+        searchButton.setOnClickListener {
+            val query = searchEditText.text.toString().trim()
+            Log.d("Search", "Search button clicked, query: $query") // 로그 추가
+            performSearch(query)
+        }
+
+        // 🔍 키보드의 "검색" 버튼 클릭 시
+        searchEditText.setOnEditorActionListener { _, actionId, _ ->
+            if (actionId == android.view.inputmethod.EditorInfo.IME_ACTION_SEARCH) {
+                val query = searchEditText.text.toString().trim()
+                Log.d("Search", "IME_ACTION_SEARCH triggered, query: $query") // 로그 추가
+                performSearch(query)
+                true
+            } else {
+                false
+            }
+        }
+
+        // 🔍 하드웨어 키보드의 엔터 키 감지
+        searchEditText.setOnKeyListener { _, keyCode, event ->
+            if (event.action == KeyEvent.ACTION_DOWN && keyCode == KeyEvent.KEYCODE_ENTER) {
+                val query = searchEditText.text.toString().trim()
+                Log.d("Search", "Hardware ENTER key pressed, query: $query") // 로그 추가
+                performSearch(query)
+                true
+            } else {
+                false
+            }
+        }
+    }
+
+    // 🔍 검색 실행
+    private fun performSearch(query: String) {
+        Log.d("Search", "Performing search for query: $query")
+        noticeUnivAdapter.filter(query)
+
+        // ✅ 검색 후 RecyclerView 최상단으로 이동
+        val recyclerView = findViewById<RecyclerView>(R.id.noticeRecyclerView)
+        recyclerView.scrollToPosition(0)
     }
 }

--- a/app/src/main/java/com/example/gaechuck/ui/noticeuniv/NoticeUnivActivity.kt
+++ b/app/src/main/java/com/example/gaechuck/ui/noticeuniv/NoticeUnivActivity.kt
@@ -1,6 +1,7 @@
 package com.example.gaechuck.ui.noticeuniv
 
 import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
 import android.util.Log
 import android.view.View
@@ -69,7 +70,9 @@ class NoticeUnivActivity : AppCompatActivity() {
     private fun initRecyclerView() {
         val recyclerView = findViewById<RecyclerView>(R.id.noticeRecyclerView)
         recyclerView.setLayerType(View.LAYER_TYPE_SOFTWARE, null)
-        noticeUnivAdapter = NoticeUnivAdapter(mutableListOf())
+        noticeUnivAdapter = NoticeUnivAdapter(mutableListOf()) { url ->
+            openUrl(url)
+        }
         recyclerView.adapter = noticeUnivAdapter
         recyclerView.layoutManager = LinearLayoutManager(this)
 
@@ -175,5 +178,10 @@ class NoticeUnivActivity : AppCompatActivity() {
         } catch (e: Exception) {
             "날짜 오류"
         }
+    }
+
+    private fun openUrl(url: String) {
+        val intent = Intent(Intent.ACTION_VIEW, Uri.parse(url))
+        startActivity(intent)
     }
 }

--- a/app/src/main/java/com/example/gaechuck/ui/noticeuniv/NoticeUnivActivity.kt
+++ b/app/src/main/java/com/example/gaechuck/ui/noticeuniv/NoticeUnivActivity.kt
@@ -63,7 +63,7 @@ class NoticeUnivActivity : AppCompatActivity() {
 
         // 데이터 로드
         Log.d("Activity", "Fetching notices onCreate")
-        viewModel.fetchNotices(0, 10, currentBbsId)
+        viewModel.fetchNotices(0, currentBbsId)
 
         val tabAll = findViewById<TextView>(R.id.tabInstitution)
 //        val tabAllUnderline = findViewById<View>(R.id.tabAllUnderline)
@@ -83,8 +83,11 @@ class NoticeUnivActivity : AppCompatActivity() {
         recyclerView.addOnScrollListener(object : RecyclerView.OnScrollListener() {
             override fun onScrolled(recyclerView: RecyclerView, dx: Int, dy: Int) {
                 val layoutManager = recyclerView.layoutManager as LinearLayoutManager
-                if (!isLoading && dy > 0 && layoutManager.findLastVisibleItemPosition() + 1 == layoutManager.itemCount) {
-                    loadMoreData()
+                val totalItemCount = layoutManager.itemCount
+                val lastVisibleItem = layoutManager.findLastVisibleItemPosition()
+
+                if (!viewModel.isLoading && viewModel.hasMoreData && lastVisibleItem + 1 >= totalItemCount) {
+                    viewModel.loadMoreNotices(currentBbsId)
                 }
             }
         })
@@ -100,12 +103,6 @@ class NoticeUnivActivity : AppCompatActivity() {
             Log.e("Activity", "Error occurred: $error")
             Toast.makeText(this, "오류 발생: $error", Toast.LENGTH_SHORT).show()
         }
-    }
-
-    private fun loadMoreData() {
-        isLoading = true
-        currentPage++
-        viewModel.fetchNotices(currentPage, itemsPerPage, currentBbsId)
     }
 
     private fun setupTabs() {
@@ -131,8 +128,9 @@ class NoticeUnivActivity : AppCompatActivity() {
             textView.setOnClickListener {
                 selectTab(textView, underlines[index])
                 currentBbsId = textView.text.toString()
-                currentPage = 0
-                viewModel.fetchNotices(currentPage, itemsPerPage, currentBbsId)
+                viewModel.hasMoreData = true
+                viewModel.currentPage = 0
+                viewModel.fetchNotices(0, currentBbsId)
             }
         }
     }

--- a/app/src/main/java/com/example/gaechuck/ui/noticeuniv/NoticeUnivActivity.kt
+++ b/app/src/main/java/com/example/gaechuck/ui/noticeuniv/NoticeUnivActivity.kt
@@ -28,7 +28,7 @@ class NoticeUnivActivity : AppCompatActivity() {
     private lateinit var dateTextView: TextView
     private var currentPage = 0
     private val itemsPerPage = 10
-    private var currentBbsId: String = "전체"
+    private var currentBbsId: String = "기관"
     private var isLoading = false
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/app/src/main/java/com/example/gaechuck/ui/noticeuniv/adaptor/NoticeUnivAdapter.kt
+++ b/app/src/main/java/com/example/gaechuck/ui/noticeuniv/adaptor/NoticeUnivAdapter.kt
@@ -8,13 +8,25 @@ import androidx.recyclerview.widget.RecyclerView
 import com.example.gaechuck.R
 import com.example.gaechuck.data.model.NoticeUnivModel
 
-class NoticeUnivAdapter(private val noticeUnivModels: MutableList<NoticeUnivModel>) :
-    RecyclerView.Adapter<NoticeUnivAdapter.NoticeViewHolder>() {
+class NoticeUnivAdapter(
+    private val noticeUnivModels: MutableList<NoticeUnivModel>,
+    private val onItemClick: (String) -> Unit
+) : RecyclerView.Adapter<NoticeUnivAdapter.NoticeViewHolder>() {
 
     class NoticeViewHolder(view: View) : RecyclerView.ViewHolder(view) {
         val title: TextView = view.findViewById(R.id.noticeTitle)
         val body: TextView = view.findViewById(R.id.noticeBody)
         val category: TextView = view.findViewById(R.id.noticeCategory)
+
+        fun bind(notice: NoticeUnivModel, onItemClick: (String) -> Unit) {
+            title.text = notice.title
+            body.text = notice.departmentName ?: "부서 없음"
+            category.text = notice.bbsId ?: "카테고리 없음"
+
+            itemView.setOnClickListener {
+                notice.url?.let { url -> onItemClick(url) }
+            }
+        }
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): NoticeViewHolder {
@@ -24,10 +36,7 @@ class NoticeUnivAdapter(private val noticeUnivModels: MutableList<NoticeUnivMode
     }
 
     override fun onBindViewHolder(holder: NoticeViewHolder, position: Int) {
-        val notice = noticeUnivModels[position]
-        holder.title.text = notice.title
-        holder.body.text = notice.departmentName ?: "부서 없음"
-        holder.category.text = notice.bbsId ?: "카테고리 없음"
+        holder.bind(noticeUnivModels[position], onItemClick)
     }
 
     override fun getItemCount(): Int = noticeUnivModels.size
@@ -41,4 +50,6 @@ class NoticeUnivAdapter(private val noticeUnivModels: MutableList<NoticeUnivMode
     fun getItem(position: Int): NoticeUnivModel? {
         return if (position in noticeUnivModels.indices) noticeUnivModels[position] else null
     }
+
+
 }

--- a/app/src/main/java/com/example/gaechuck/ui/noticeuniv/adaptor/NoticeUnivAdapter.kt
+++ b/app/src/main/java/com/example/gaechuck/ui/noticeuniv/adaptor/NoticeUnivAdapter.kt
@@ -38,21 +38,7 @@ class NoticeUnivAdapter(private val noticeUnivModels: MutableList<NoticeUnivMode
         notifyDataSetChanged()
     }
 
-    fun addNotices(newNoticeUnivModels: List<NoticeUnivModel>) {
-        val startPosition = noticeUnivModels.size
-        noticeUnivModels.addAll(newNoticeUnivModels)
-        notifyItemRangeInserted(startPosition, newNoticeUnivModels.size)
-    }
-
-
-    private fun getCategoryByBbsId(id: Int): String {
-        return when (id) {
-            1 -> "학사"
-            2 -> "기관"
-            3 -> "채용"
-            4 -> "장학"
-            5 -> "입법예고"
-            else -> "기타"
-        }
+    fun getItem(position: Int): NoticeUnivModel? {
+        return if (position in noticeUnivModels.indices) noticeUnivModels[position] else null
     }
 }

--- a/app/src/main/java/com/example/gaechuck/ui/noticeuniv/adaptor/NoticeUnivAdapter.kt
+++ b/app/src/main/java/com/example/gaechuck/ui/noticeuniv/adaptor/NoticeUnivAdapter.kt
@@ -1,5 +1,6 @@
 package com.example.gaechuck.ui.noticeuniv.adaptor
 
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -7,11 +8,14 @@ import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView
 import com.example.gaechuck.R
 import com.example.gaechuck.data.model.NoticeUnivModel
+import retrofit2.http.Query
 
 class NoticeUnivAdapter(
     private val noticeUnivModels: MutableList<NoticeUnivModel>,
     private val onItemClick: (String) -> Unit
 ) : RecyclerView.Adapter<NoticeUnivAdapter.NoticeViewHolder>() {
+
+    private var filteredNotices: List<NoticeUnivModel> = noticeUnivModels.toList()
 
     class NoticeViewHolder(view: View) : RecyclerView.ViewHolder(view) {
         val title: TextView = view.findViewById(R.id.noticeTitle)
@@ -36,14 +40,15 @@ class NoticeUnivAdapter(
     }
 
     override fun onBindViewHolder(holder: NoticeViewHolder, position: Int) {
-        holder.bind(noticeUnivModels[position], onItemClick)
+        holder.bind(filteredNotices[position], onItemClick)
     }
 
-    override fun getItemCount(): Int = noticeUnivModels.size
+    override fun getItemCount(): Int = filteredNotices.size
 
     fun setNotices(newNotices: List<NoticeUnivModel>) {
         noticeUnivModels.clear()
         noticeUnivModels.addAll(newNotices)
+        filteredNotices = newNotices.toList()
         notifyDataSetChanged()
     }
 
@@ -51,5 +56,18 @@ class NoticeUnivAdapter(
         return if (position in noticeUnivModels.indices) noticeUnivModels[position] else null
     }
 
+//    override fun getItemCount(): Int = filteredNotices.size
+
+    fun filter(query: String) {
+        filteredNotices = if (query.isEmpty()) {
+            noticeUnivModels.toList() // 검색어 없을 경우 전체 리스트 유지
+        } else {
+            noticeUnivModels.filter {
+                it.title.contains(query, ignoreCase = true) // 제목에서만 검색
+            }
+        }
+        Log.d("Search", "Filtered items count: ${filteredNotices.size}") // 로그 추가
+        notifyDataSetChanged() // UI 갱신
+    }
 
 }

--- a/app/src/main/java/com/example/gaechuck/ui/noticeuniv/viewmodel/NoticeUnivViewModel.kt
+++ b/app/src/main/java/com/example/gaechuck/ui/noticeuniv/viewmodel/NoticeUnivViewModel.kt
@@ -16,18 +16,39 @@ class NoticeUnivViewModel(private val repository: NoticeUnivRepository) : ViewMo
     private val _errorMessage = MutableLiveData<String>()
     val errorMessage: LiveData<String> get() = _errorMessage
 
-    fun fetchNotices(page: Int, pageSize: Int, bbsId: String) {
-        viewModelScope.launch {
-            Log.d("ViewModel", "Fetching notices: page=$page, pageSize=$pageSize, bbsId=$bbsId")
+    private var currentList: MutableList<NoticeUnivModel> = mutableListOf()
+    var isLoading = false
+    var hasMoreData = true
+    var currentPage = 0
 
+    fun fetchNotices(page: Int = 0, bbsId: String) {
+        if (isLoading || !hasMoreData) return // 불러올 데이터가 없는 경우 중단
+
+        isLoading = true
+        viewModelScope.launch {
             try {
-                val noticeList = repository.getNoticeUnivList(page, pageSize, bbsId)
-                _notices.postValue(noticeList)
-                Log.d("ViewModel", "Data fetched successfully: ${noticeList.size} items")
+                Log.d("VIEWMODEL", "Fetching page: $page for bbsId: $bbsId")
+
+                val (newNotices, hasNextPage) = repository.getNoticeUnivList(page, bbsId)
+
+                if (page == 0) { currentList.clear() }
+                currentList.addAll(newNotices)
+
+                _notices.value = currentList
+                hasMoreData = hasNextPage
+                currentPage = page
+
             } catch (e: Exception) {
-                Log.e("ViewModel", "Error fetching notices: ${e.message}")
-                _errorMessage.postValue("오류 발생: ${e.message}")
+                _errorMessage.value = e.message
+            } finally {
+                isLoading = false
             }
+        }
+    }
+
+    fun loadMoreNotices(bbsId: String) {
+        if (!isLoading && hasMoreData) {
+            fetchNotices(currentPage + 1, bbsId)
         }
     }
 }

--- a/app/src/main/java/com/example/gaechuck/ui/noticeuniv/viewmodel/NoticeUnivViewModel.kt
+++ b/app/src/main/java/com/example/gaechuck/ui/noticeuniv/viewmodel/NoticeUnivViewModel.kt
@@ -38,6 +38,8 @@ class NoticeUnivViewModel(private val repository: NoticeUnivRepository) : ViewMo
                 hasMoreData = hasNextPage
                 currentPage = page
 
+                Log.d("VIEWMODEL", "Total items fetched so far: ${currentList.size}")
+
             } catch (e: Exception) {
                 _errorMessage.value = e.message
             } finally {

--- a/app/src/main/res/layout/activity_notice_univ.xml
+++ b/app/src/main/res/layout/activity_notice_univ.xml
@@ -77,14 +77,18 @@
             android:background="@null"
             android:hint="내용을 검색해보세요"
             android:textSize="12sp"
-            android:padding="8dp" />
+            android:padding="8dp"
+            android:imeOptions="actionSearch"
+            android:inputType="text"/>
 
         <ImageView
             android:id="@+id/searchButton"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:padding="8dp"
-            android:src="@drawable/search_icon" />
+            android:src="@drawable/search_icon"
+            android:clickable="true"
+            android:focusable="true"/>
     </LinearLayout>
 
     <!-- 탭 -->

--- a/app/src/main/res/layout/activity_notice_univ.xml
+++ b/app/src/main/res/layout/activity_notice_univ.xml
@@ -95,33 +95,6 @@
         android:gravity="center"
         android:paddingTop="8dp">
 
-<!--        <LinearLayout-->
-<!--            android:id="@+id/tabAllLayout"-->
-<!--            android:layout_width="0dp"-->
-<!--            android:layout_height="wrap_content"-->
-<!--            android:layout_weight="1"-->
-<!--            android:orientation="vertical"-->
-<!--            android:gravity="center">-->
-
-<!--            <TextView-->
-<!--                android:id="@+id/tabAll"-->
-<!--                android:layout_width="wrap_content"-->
-<!--                android:layout_height="wrap_content"-->
-<!--                android:text="전체"-->
-<!--                android:padding="8dp"-->
-<!--                android:gravity="center"-->
-<!--                android:textColor="@color/tab_colors" />-->
-
-<!--            <View-->
-<!--                android:id="@+id/tabAllUnderline"-->
-<!--                android:layout_width="wrap_content"-->
-<!--                android:layout_height="4dp"-->
-<!--                android:visibility="invisible"-->
-<!--                android:layout_marginStart="16dp"-->
-<!--                android:layout_marginEnd="16dp"-->
-<!--                android:background="@color/gnu_blue" />-->
-<!--        </LinearLayout>-->
-
         <LinearLayout
             android:id="@+id/tabInstitutionLayout"
             android:layout_width="0dp"


### PR DESCRIPTION
# Tab 수정사항 반영 (전체 탭 제거, bbsId 오류)
<img width="377" alt="image" src="https://github.com/user-attachments/assets/43bf8da9-b7a8-4eea-b902-bc067da627df" />

### 기존 오류
-  `기관` bbsId에서 `학사` bbsId의 데이터가 반환되는 오류 발생
- 초기 데이터를 `전체` bbsId로 불러오도록 코드가 작성되었음 -> UI 수정에 따라 `전체` 제거 필요

### 수정사항
- `기관` bbsId를 제대로 요청할 수 있도록 Repository 수정
- 이전 UI에서 `전체` bbsId가 삭제됨에 따라 초기 값으로 `기관` bbsId로 초기 값 전송하도록 수정

<img width="456" alt="image" src="https://github.com/user-attachments/assets/e1c17e49-4c8c-401d-82ed-9c3d5a6f6f92" />
<img width="304" alt="image" src="https://github.com/user-attachments/assets/7bf607b3-a062-4ad1-b497-9132211f046c" />

### 수정예정사항
- api 명세서에 명시된 size 존재 의미를 잘 모르겠음 추후 마무리 작업 시 적용 예정

# 교내공지 URL 연결 추가
- 클릭 시 url 연결되도록 추가
- 현재 안드로이드 스튜디오 내장 디바이스에서는 네트워크 연결이 불가능해서 경로 연결 과정까지만 체킹 가능, 실제 제대로 된 경로를 불러오는지는 확인 불가
<img width="474" alt="image" src="https://github.com/user-attachments/assets/46f28ecc-f711-4ff1-9ecf-03d0a2fbfc82" />


# 검색 기능 구현
- 검색은 Title에서 검색이 되도록 하며
- 탭 이동시 검색어를 refresh 한 후 데이터를 불러오도록 함
<img width="470" alt="image" src="https://github.com/user-attachments/assets/6a07accb-55aa-4db2-80c4-97842592a5da" />

- pagenation 무한스크롤 부분과 날짜 동적 변경 사항도 정상적으로 구현 완료